### PR TITLE
Use SQLAlchemy engine for pandas queries

### DIFF
--- a/modules/db_tools/crud_operations.py
+++ b/modules/db_tools/crud_operations.py
@@ -8,6 +8,8 @@ from .db_connection import get_engine
 
 def _read_sql(query, params=None):
     """Helper to execute SQL queries and return a DataFrame."""
+    if isinstance(params, list):
+        params = tuple(params)
     return pd.read_sql(query, get_engine(), params=params)
 
 

--- a/modules/db_tools/db_connection.py
+++ b/modules/db_tools/db_connection.py
@@ -1,12 +1,27 @@
 """Database connection management."""
+import os
+
 import psycopg2
 import streamlit as st
-import os
+from sqlalchemy import create_engine
 
 from dotenv import load_dotenv
 
 
 load_dotenv()
+
+
+def _create_engine():
+    """Create a new SQLAlchemy engine for the database."""
+    return create_engine(
+        "postgresql+psycopg2://{}:{}@{}:{}/{}".format(
+            os.getenv("SUPABASE_DB_USER"),
+            os.getenv("SUPABASE_DB_PASSWORD"),
+            os.getenv("SUPABASE_DB_HOST"),
+            os.getenv("SUPABASE_DB_PORT"),
+            os.getenv("SUPABASE_DB_NAME"),
+        )
+    )
 
 
 def _create_connection():
@@ -18,6 +33,15 @@ def _create_connection():
         host=os.getenv("SUPABASE_DB_HOST"),
         port=os.getenv("SUPABASE_DB_PORT"),
     )
+
+
+def get_engine():
+    """Return a SQLAlchemy engine, creating it if necessary."""
+    engine = st.session_state.get("db_engine")
+    if engine is None:
+        engine = _create_engine()
+        st.session_state["db_engine"] = engine
+    return engine
 
 
 def get_connection():

--- a/modules/reports_page.py
+++ b/modules/reports_page.py
@@ -11,6 +11,7 @@ from modules.db_tools.crud_operations import (
     get_special_transactions_balance,
 )
 from modules.db_tools.filters import get_allowed_building_df
+from modules.db_tools.db_connection import get_engine
 
 
 def render(conn, T):
@@ -238,7 +239,7 @@ def render(conn, T):
                 q += " AND t.method = %s"
                 params.append(payment_method)
             q += " ORDER BY t.payment_date DESC"
-            df_trans = pd.read_sql(q, conn, params=params)
+            df_trans = pd.read_sql(q, get_engine(), params=params)
             total_paid = 0
             if not df_trans.empty:
                 df_trans["payment_date"] = pd.to_datetime(df_trans["payment_date"], errors="coerce")
@@ -276,7 +277,7 @@ def render(conn, T):
                 q += " AND e.status = %s"
                 params.append(expense_status)
             q += " ORDER BY e.start_date DESC"
-            df_expenses = pd.read_sql(q, conn, params=params)
+            df_expenses = pd.read_sql(q, get_engine(), params=params)
             total_cost = 0
             if not df_expenses.empty:
                 df_expenses["start_date"] = pd.to_datetime(df_expenses["start_date"], errors="coerce")

--- a/modules/reports_page.py
+++ b/modules/reports_page.py
@@ -239,7 +239,7 @@ def render(conn, T):
                 q += " AND t.method = %s"
                 params.append(payment_method)
             q += " ORDER BY t.payment_date DESC"
-            df_trans = pd.read_sql(q, get_engine(), params=params)
+            df_trans = pd.read_sql(q, get_engine(), params=tuple(params))
             total_paid = 0
             if not df_trans.empty:
                 df_trans["payment_date"] = pd.to_datetime(df_trans["payment_date"], errors="coerce")
@@ -277,7 +277,7 @@ def render(conn, T):
                 q += " AND e.status = %s"
                 params.append(expense_status)
             q += " ORDER BY e.start_date DESC"
-            df_expenses = pd.read_sql(q, get_engine(), params=params)
+            df_expenses = pd.read_sql(q, get_engine(), params=tuple(params))
             total_cost = 0
             if not df_expenses.empty:
                 df_expenses["start_date"] = pd.to_datetime(df_expenses["start_date"], errors="coerce")


### PR DESCRIPTION
## Summary
- add reusable SQLAlchemy engine for database access
- route pandas read_sql calls through this engine to avoid connection warnings

## Testing
- `python -m py_compile modules/db_tools/db_connection.py modules/db_tools/crud_operations.py modules/reports_page.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c19546abdc832fab59741de8b399db